### PR TITLE
Fix compatibility issues due to ModsConfig.IsActive

### DIFF
--- a/1.4/Source/VFEPirates/VFEPirates/Utilities/ModCompatibility.cs
+++ b/1.4/Source/VFEPirates/VFEPirates/Utilities/ModCompatibility.cs
@@ -13,8 +13,11 @@ namespace VFEPirates
 	public static class ModCompatibility
 	{
 		static ModCompatibility()
-        {
-			DubsBadHygieneActive = ModsConfig.IsActive("Dubwise.DubsBadHygiene") || ModsConfig.IsActive("Dubwise.DubsBadHygiene.Lite");
+		{
+			DubsBadHygieneActive = ModsConfig.IsActive("Dubwise.DubsBadHygiene")
+			                       || ModsConfig.IsActive("Dubwise.DubsBadHygiene_steam")
+			                       || ModsConfig.IsActive("Dubwise.DubsBadHygiene.Lite")
+			                       || ModsConfig.IsActive("Dubwise.DubsBadHygiene.Lite_steam");
 		}
 
 		public static void FillBladderNeed(Pawn pawn, float value) 


### PR DESCRIPTION
The issue occurs when checking if a mod is active with `ModsConfig.IsActive` when running the workshop version of a mod while there's a local copy in the mods directory. In those cases the `ModsConfig.IsActive` will return false as the running mod will have the `_steam` postfix.

The simple fix is to simply check for mod ID, as well as the mod ID with the `_steam` postfix.

For related PRs, check:
Vanilla-Expanded/VanillaExpandedFramework#72