### PR TITLE
Fix warcasket foundry exception related to inspect string

### DIFF
--- a/1.5/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/1.5/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -4,9 +4,7 @@
 		<canOverlapZones>true</canOverlapZones>
 		<terrainAffordanceNeeded>Heavy</terrainAffordanceNeeded>
 		<comps>
-			<li>
-				<compClass>CompReportWorkSpeed</compClass>
-			</li>
+			<li Class="CompProperties_ReportWorkSpeed"/>
 		</comps>
 		<placeWorkers>
 			<li>PlaceWorker_ReportWorkSpeedPenalties</li>


### PR DESCRIPTION
In 1.5, `CompReportWorkSpeed` received a `CompProperties_ReportWorkSpeed` class that corresponds to it. The comp always assumes that the props class is non-null. This causes issues here as warcasket foundry did not define the props class, since it was not needed until now.

This should fix it by defining the props class instead of just providing the `compClass`.

The error that happens without this change:

```
GetInspectString exception on VFEP_WarcasketFoundry13925:
System.InvalidCastException: Specified cast is not valid.
[Ref 5DDA12B2]
 at RimWorld.CompReportWorkSpeed.CompInspectStringExtra () [0x000d4] in <8ee6c9f7570646cabb8981ee61cb9b87>:0 
 at Verse.ThingWithComps.InspectStringPartsFromComps () [0x00020] in <8ee6c9f7570646cabb8981ee61cb9b87>:0 
 at Verse.ThingWithComps.GetInspectString () [0x00013] in <8ee6c9f7570646cabb8981ee61cb9b87>:0 
 at RimWorld.InspectPaneFiller.DrawInspectStringFor (Verse.ISelectable sel, UnityEngine.Rect rect) [0x00000] in <8ee6c9f7570646cabb8981ee61cb9b87>:0 
UnityEngine.StackTraceUtility:ExtractStackTrace ()
(wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition:Verse.Log.Error_Patch1 (string)
RimWorld.InspectPaneFiller:DrawInspectStringFor (Verse.ISelectable,UnityEngine.Rect)
RimWorld.InspectPaneFiller:DoPaneContentsFor (Verse.ISelectable,UnityEngine.Rect)
RimWorld.MainTabWindow_Inspect:DoPaneContents (UnityEngine.Rect)
RimWorld.InspectPaneUtility:InspectPaneOnGUI (UnityEngine.Rect,RimWorld.IInspectPane)
RimWorld.MainTabWindow_Inspect:DoWindowContents (UnityEngine.Rect)
Verse.Window:InnerWindowOnGUI (int)
UnityEngine.GUI:CallWindowDelegate (UnityEngine.GUI/WindowFunction,int,int,UnityEngine.GUISkin,int,single,single,UnityEngine.GUIStyle)
````