### PR TITLE
Fix drawing issues with PawnFlyer_Pulled and slight flyer improvements

### DIFF
--- a/1.5/Defs/AbilityDefs/Abilities.xml
+++ b/1.5/Defs/AbilityDefs/Abilities.xml
@@ -44,6 +44,7 @@
         <pawnFlyer>
             <flightDurationMin>0.2</flightDurationMin>
             <flightSpeed>20</flightSpeed>
+			<workerClass>VFEPirates.PawnFlyerWorker_Pulled</workerClass>
         </pawnFlyer>
     </ThingDef>
 	
@@ -91,6 +92,7 @@
 		<targetMode>Location</targetMode>
 		<iconPath>UI/Abilities/PowerJump</iconPath>
 		<castTime>60</castTime>
+		<keepCarryingThing>true</keepCarryingThing>
 		<modExtensions>
 			<li Class="VFEPirates.PowerJumpExtension">
 				<fuelConsumption>20</fuelConsumption>

--- a/1.5/Defs/AbilityDefs/Abilities.xml
+++ b/1.5/Defs/AbilityDefs/Abilities.xml
@@ -44,7 +44,7 @@
         <pawnFlyer>
             <flightDurationMin>0.2</flightDurationMin>
             <flightSpeed>20</flightSpeed>
-			<workerClass>VFEPirates.PawnFlyerWorker_Pulled</workerClass>
+            <workerClass>VFEPirates.PawnFlyerWorker_Pulled</workerClass>
         </pawnFlyer>
     </ThingDef>
 	

--- a/1.5/Source/VFEPirates/VFEPirates/Abilities/Ability_GrapplingHook.cs
+++ b/1.5/Source/VFEPirates/VFEPirates/Abilities/Ability_GrapplingHook.cs
@@ -105,9 +105,12 @@ namespace VFEPirates
         {
             ticksTillPull = -2;
             var destCell = usedTarget.Thing.OccupiedRect().AdjacentCells.MinBy(cell => cell.DistanceTo(launcher.Position));
+            var selected = Find.Selector.IsSelected(ability.pawn);
             var flyer = (PawnFlyer_Pulled) PawnFlyer.MakeFlyer(VFEP_DefOf.VFEP_GrapplingPawn, ability.pawn, destCell, null, null);
             flyer.Hook = this;
             GenSpawn.Spawn(flyer, destCell, Map);
+            if (selected)
+                Find.Selector.Select(ability.pawn);
         }
 
         protected override void DrawAt(Vector3 drawLoc, bool flip = false)
@@ -132,18 +135,7 @@ namespace VFEPirates
 
     public class PawnFlyer_Pulled : PawnFlyer
     {
-        protected Vector3 effectivePos;
         public Projectile_GrapplingHook Hook;
-        private int positionLastComputedTick;
-
-        public override Vector3 DrawPos
-        {
-            get
-            {
-                RecomputePosition();
-                return effectivePos;
-            }
-        }
 
         protected override void RespawnPawn()
         {
@@ -156,30 +148,14 @@ namespace VFEPirates
             base.ExposeData();
             Scribe_References.Look(ref Hook, "hook");
         }
+    }
 
-        public override void Tick()
+    public class PawnFlyerWorker_Pulled : PawnFlyerWorker
+    {
+        public PawnFlyerWorker_Pulled(PawnFlyerProperties properties) : base(properties)
         {
-            base.Tick();
-            if (FlyingPawn != null) RecomputePosition();
         }
 
-        protected bool CheckRecompute()
-        {
-            if (positionLastComputedTick == ticksFlying) return false;
-
-            positionLastComputedTick = ticksFlying;
-            return true;
-        }
-
-        protected virtual void RecomputePosition()
-        {
-            if (CheckRecompute()) return;
-            effectivePos = Vector3.Lerp(startVec, DestinationPos, ticksFlying / (float) ticksFlightTime);
-        }
-
-        protected override void DrawAt(Vector3 drawLoc, bool flip = false)
-        {
-            FlyingPawn.DynamicDrawPhaseAt(DrawPhase.Draw, drawLoc, flip);
-        }
+        public override float GetHeight(float t) => 0f;
     }
 }

--- a/1.5/Source/VFEPirates/VFEPirates/Abilities/Ability_PowerJump.cs
+++ b/1.5/Source/VFEPirates/VFEPirates/Abilities/Ability_PowerJump.cs
@@ -50,7 +50,7 @@ namespace VFEPirates
 
             var destCell = targets[0].Cell;
             AbilityPawnFlyer flyer = (PawnFlyer_PowerJump)PawnFlyer.MakeFlyer(VFEP_DefOf.VFEP_PowerJumpPawn, pawn, destCell, 
-                null, null);
+                null, null, true);
             flyer.ability = this;
             flyer.DestinationCell = destCell;
             GenSpawn.Spawn(flyer, destCell, map);


### PR DESCRIPTION
`PawnFlyer_Pulled` was drawing the pawn being drawn twice, as vanilla drawing code was still being triggered. To fix this the pawn drawing code was removed, and `PawnFlyerWorker_Pulled` was added (which will set the flyer's height to 0 in vanilla's drawing code, achieving the same effect).

`PawnFlyer_Pulled` will now reselect the pawn if they were selected (this flyer does not benefit from Vanilla-Expanded/VanillaExpandedFramework/pull/89 as it is used by a vanilla ability, not VFE one).

`PawnFlyer_PowerJump` will now keep carrying the pawn while flying. However, no such change was made to `PawnFlyer_Pulled` as it's not easily possible without more changes to how the grappling hook ability work.